### PR TITLE
Replace use of tempfile(1) with mktemp(1)

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,0 +1,14 @@
+PROGRAMS=org-tangle org-weave
+TARGETS=$(PROGRAMS) README.md org-tangle.md org-weave.md
+
+all: $(TARGETS)
+
+%: %.org
+	./org-tangle -l emacs-lisp,org $<
+
+%.md: %.org
+	./org-weave -f gfm -O '-Q --batch -L ~/.emacs.d/local-packages' $< > $@
+
+DESTDIR=/home/soft/bin
+install: all
+	install -m 755 $(PROGRAMS) $(DESTDIR)

--- a/org-tangle
+++ b/org-tangle
@@ -4,7 +4,7 @@ DIR=`pwd`
 FILES=""
 ORGDIR="/path/to/alternate/org-mode"
 QUICK_EXPANSION=nil
-EMACS=emacs24-nox
+EMACS=emacs
 EMACS_OPTS="-Q --batch"
 VERSION=0.1
 

--- a/org-tangle.md
+++ b/org-tangle.md
@@ -145,7 +145,7 @@ Options:
     Create a temporary file
     
     ```sh
-    out=$(tempfile)
+    out=$(mktemp)
     ```
     
     Now, execute emacs&#x2026;

--- a/org-tangle.org
+++ b/org-tangle.org
@@ -99,7 +99,7 @@ Wrap each argument in the code required to call tangle on it
 Create a temporary file
 #+name: src
 #+begin_src sh
-  out=$(tempfile)
+  out=$(mktemp)
 #+end_src
 
 Now, execute emacs...

--- a/org-tangle.org
+++ b/org-tangle.org
@@ -49,7 +49,7 @@ Options:
 =<<emacs>>= =
 #+name: emacs
 #+begin_src sh
-  emacs24-nox
+  emacs
 #+end_src
 
 *** Help function

--- a/org-weave
+++ b/org-weave
@@ -43,7 +43,7 @@ file="$1"
 
 [ "$FLAVOR" = "gfm" ] || { help && exit 1; }
 
-out=$(tempfile)
+out=$(mktemp)
 
 $EMACS ${EMACS_OPTS} --eval "(progn
   (package-initialize)

--- a/org-weave.md
+++ b/org-weave.md
@@ -141,7 +141,7 @@ Options:
     Create a temporary file
     
     ```sh
-    out=$(tempfile)
+    out=$(mktemp)
     ```
     
     Now, execute emacs&#x2026;

--- a/org-weave.org
+++ b/org-weave.org
@@ -102,7 +102,7 @@ For now, only gfm is supported
 Create a temporary file
 #+name: src
 #+begin_src sh
-  out=$(tempfile)
+  out=$(mktemp)
 #+end_src
 
 Now, execute emacs...


### PR DESCRIPTION
Proposing a minor change to the project. Instead of using `tempfile` for creating a temporary file, UNIX manpages now advice using `mktemp`.  I created a merge that implements this change.

Additional changes:
1. I also changed "emacs24-nox" to "emacs" in org-tangle file (feel free to revert this change if you don't like it).
2. I added a makefile to the project based on what you had put in the README.

Link to tempfile manpage: [https://www.unix.com/man-page/Linux/1/tempfile/](https://www.unix.com/man-page/Linux/1/tempfile/). See section titled BUGS for deprecation warning.

Lastly, thanks for creating this excellent project. I am using it as part of my own literate-programming workflow. 👋🏽 